### PR TITLE
Fix for an argument type error of setColumnWidth()

### DIFF
--- a/addFeatureGUI.py
+++ b/addFeatureGUI.py
@@ -207,7 +207,7 @@ class AddFeatureGUI(QDialog, Ui_numericalDigitize_MainDialog):
 
         # Resize grid. Set column's width equal. Resize the section to fill the available space.
         for i in range(self.twPoints.columnCount()):    
-            self.twPoints.setColumnWidth(i, self.twPoints.width()/self.twPoints.columnCount())
+            self.twPoints.setColumnWidth(i, int(self.twPoints.width()/self.twPoints.columnCount()))
             self.twPoints.horizontalHeader().setSectionResizeMode(i, QHeaderView.Stretch)
 
         # Disable OK button. Wait for entering valid coordinates


### PR DESCRIPTION
When we use the NumericalDigital plugin on QGIS ver. 3.18+, an error is occurred that comes from type mismatch of arguments in the setColumnWidth() function. 
At StackExchange, [a fix method](https://gis.stackexchange.com/a/456164) is reported by [Kadir Şahbaz](https://gis.stackexchange.com/users/29431/kadir-%c5%9eahbaz) and it works well on the latest QGIS ver. 3.38.0. 

This commit is just a request so that we can continue using this plugin on QGIS ver. 3.18+.
Thank you. 